### PR TITLE
Install h2 1.4.195 in test environment in BuildConfig.groovy (fixes #7)

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -74,4 +74,12 @@ grails.project.dependency.resolution = {
         compile ':webxml:1.4.1'
         compile ":hibernate4:4.3.10"
     }
+
+    environments {
+        test {
+            dependencies {
+                compile "com.h2database:h2:1.4.195"
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes #7.

To my knowledge, this is only used in tests, so I placed the dependency in a test only environment block.

I had to go with h2 1.4.195, for some reason, the latest version 1.4.197 threw errors like this when I tried to run the tests:

```
2018-12-19 14:57:57,418 [exchange-worker-#42%grid%] ERROR cache.GridCachePartitionExchangeManager  - Failed to wait for completion of partition map exchange (preloading will not start): GridDhtPartitionsExchangeFuture [firstDiscoEvt=DiscoveryEvent [evtNode=TcpDiscoveryNode [id=4738ae68-ed8f-4a5a-89c5-c546348821dd, addrs=[0:0:0:0:0:0:0:1, 127.0.0.1, 192.168.145.125, 192.168.56.1, 192.168.99.1], sockAddrs=[/192.168.145.125:47500, JOSHUA/192.168.99.1:47500, /0:0:0:0:0:0:0:1:47500, /127.0.0.1:47500, /192.168.56.1:47500], discPort=47500, order=1, intOrder=1, lastExchangeTime=1545260275025, loc=true, ver=2.6.0#20180710-sha1:669feacc, isClient=false], topVer=1, nodeId8=4738ae68, msg=null, type=NODE_JOINED, tstamp=1545260277113], crd=TcpDiscoveryNode [id=4738ae68-ed8f-4a5a-89c5-c546348821dd, addrs=[0:0:0:0:0:0:0:1, 127.0.0.1, 192.168.145.125, 192.168.56.1, 192.168.99.1], sockAddrs=[/192.168.145.125:47500, JOSHUA/192.168.99.1:47500, /0:0:0:0:0:0:0:1:47500, /127.0.0.1:47500, /192.168.56.1:47500], discPort=47500, order=1, intOrder=1, lastExchangeTime=1545260275025, loc=true, ver=2.6.0#20180710-sha1:669feacc, isClient=false], exchId=GridDhtPartitionExchangeId [topVer=AffinityTopologyVersion [topVer=1, minorTopVer=0], discoEvt=DiscoveryEvent [evtNode=TcpDiscoveryNode [id=4738ae68-ed8f-4a5a-89c5-c546348821dd, addrs=[0:0:0:0:0:0:0:1, 127.0.0.1, 192.168.145.125, 192.168.56.1, 192.168.99.1], sockAddrs=[/192.168.145.125:47500, JOSHUA/192.168.99.1:47500, /0:0:0:0:0:0:0:1:47500, /127.0.0.1:47500, /192.168.56.1:47500], discPort=47500, order=1, intOrder=1, lastExchangeTime=1545260275025, loc=true, ver=2.6.0#20180710-sha1:669feacc, isClient=false], topVer=1, nodeId8=4738ae68, msg=null, type=NODE_JOINED, tstamp=1545260277113], nodeId=4738ae68, evt=NODE_JOINED], added=true, initFut=GridFutureAdapter [ignoreInterrupts=false, state=DONE, res=false, hash=1755687645], init=false, lastVer=null, partReleaseFut=null, exchActions=null, affChangeMsg=null, initTs=1545260277168, centralizedAff=false, forceAffReassignment=false, changeGlobalStateE=null, done=true, state=CRD, evtLatch=0, remaining=[], super=GridFutureAdapter [ignoreInterrupts=false, state=DONE, res=class o.a.i.i.processors.query.IgniteSQLException: Failed to initialize DB connection: jdbc:h2:mem:4738ae68-ed8f-4a5a-89c5-c546348821dd;LOCK_MODE=3;MULTI_THREADED=1;DB_CLOSE_ON_EXIT=FALSE;DEFAULT_LOCK_TIMEOUT=10000;FUNCTIONS_IN_SCHEMA=true;OPTIMIZE_REUSE_RESULTS=0;QUERY_CACHE_SIZE=0;RECOMPILE_ALWAYS=1;MAX_OPERATION_MEMORY=0;NESTED_JOINS=0;BATCH_JOINS=1;ROW_FACTORY="o.a.i.i.processors.query.h2.opt.GridH2PlainRowFactory";DEFAULT_TABLE_ENGINE=o.a.i.i.processors.query.h2.opt.GridH2DefaultTableEngine, hash=267523139]]
Message: Failed to initialize DB connection: jdbc:h2:mem:4738ae68-ed8f-4a5a-89c5-c546348821dd;LOCK_MODE=3;MULTI_THREADED=1;DB_CLOSE_ON_EXIT=FALSE;DEFAULT_LOCK_TIMEOUT=10000;FUNCTIONS_IN_SCHEMA=true;OPTIMIZE_REUSE_RESULTS=0;QUERY_CACHE_SIZE=0;RECOMPILE_ALWAYS=1;MAX_OPERATION_MEMORY=0;NESTED_JOINS=0;BATCH_JOINS=1;ROW_FACTORY="org.apache.ignite.internal.processors.query.h2.opt.GridH2PlainRowFactory";DEFAULT_TABLE_ENGINE=org.apache.ignite.internal.processors.query.h2.opt.GridH2DefaultTableEngine
    Line | Method
->> 7307 | cast    in org.apache.ignite.internal.util.IgniteUtils
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
|    259 | resolve in org.apache.ignite.internal.util.future.GridFutureAdapter
|    207 | get0 .  in     ''
|    159 | get     in     ''
|    151 | get . . in     ''
|   2433 | body0   in org.apache.ignite.internal.processors.cache.GridCachePartitionExchangeManager$ExchangeWorker
|   2299 | body .  in     ''
|    110 | run     in org.apache.ignite.internal.util.worker.GridWorker
^    745 | run . . in java.lang.Thread
Caused by IgniteSQLException: Failed to initialize DB connection: jdbc:h2:mem:4738ae68-ed8f-4a5a-89c5-c546348821dd;LOCK_MODE=3;MULTI_THREADED=1;DB_CLOSE_ON_EXIT=FALSE;DEFAULT_LOCK_TIMEOUT=10000;FUNCTIONS_IN_SCHEMA=true;OPTIMIZE_REUSE_RESULTS=0;QUERY_CACHE_SIZE=0;RECOMPILE_ALWAYS=1;MAX_OPERATION_MEMORY=0;NESTED_JOINS=0;BATCH_JOINS=1;ROW_FACTORY="org.apache.ignite.internal.processors.query.h2.opt.GridH2PlainRowFactory";DEFAULT_TABLE_ENGINE=org.apache.ignite.internal.processors.query.h2.opt.GridH2DefaultTableEngine
->>  330 | initialValue in org.apache.ignite.internal.processors.query.h2.IgniteH2Indexing$1
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
|    298 | initialValue in     ''
|    180 | setInitialValue in java.lang.ThreadLocal
|    170 | get     in     ''
|    300 | get . . in org.apache.ignite.internal.processors.query.h2.IgniteH2Indexing$1
|    298 | get     in     ''
|    524 | connectionForThread in org.apache.ignite.internal.processors.query.h2.IgniteH2Indexing
|    592 | executeStatement in     ''
|    561 | createSchema in     ''
|   2760 | registerCache in     ''
|   1594 | registerCache0 in org.apache.ignite.internal.processors.query.GridQueryProcessor
|    799 | onCacheStart0 in     ''
|    860 | onCacheStart in     ''
|   1212 | startCache in org.apache.ignite.internal.processors.cache.GridCacheProcessor
|   1964 | prepareCacheStart in     ''
|   1830 | startCachesOnLocalJoin in     ''
|    792 | initCachesOnLocalJoin in org.apache.ignite.internal.processors.cache.distributed.dht.preloader.GridDhtPartitionsExchangeFuture
|    674 | init    in     ''
|   2419 | body0 . in org.apache.ignite.internal.processors.cache.GridCachePartitionExchangeManager$ExchangeWorker
|   2299 | body    in     ''
|    110 | run . . in org.apache.ignite.internal.util.worker.GridWorker
^    745 | run     in java.lang.Thread
Caused by JdbcSQLException: Unsupported connection setting "NESTED_JOINS" [90113-197]
->>  357 | getJdbcSQLException in org.h2.message.DbException
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
|    179 | get     in     ''
|    155 | get . . in     ''
|    268 | readSettingsFromURL in org.h2.engine.ConnectionInfo
|     76 | <init>  in     ''
|    103 | <init>  in org.h2.jdbc.JdbcConnection
|     69 | connect in org.h2.Driver
|    664 | getConnection in java.sql.DriverManager
|    270 | getConnection in     ''
|    327 | initialValue in org.apache.ignite.internal.processors.query.h2.IgniteH2Indexing$1
|    298 | initialValue in     ''
|    180 | setInitialValue in java.lang.ThreadLocal
|    170 | get . . in     ''
|    300 | get     in org.apache.ignite.internal.processors.query.h2.IgniteH2Indexing$1
|    298 | get . . in     ''
|    524 | connectionForThread in org.apache.ignite.internal.processors.query.h2.IgniteH2Indexing
|    592 | executeStatement in     ''
|    561 | createSchema in     ''
|   2760 | registerCache in     ''
|   1594 | registerCache0 in org.apache.ignite.internal.processors.query.GridQueryProcessor
|    799 | onCacheStart0 in     ''
|    860 | onCacheStart in     ''
|   1212 | startCache in org.apache.ignite.internal.processors.cache.GridCacheProcessor
|   1964 | prepareCacheStart in     ''
|   1830 | startCachesOnLocalJoin in     ''
|    792 | initCachesOnLocalJoin in org.apache.ignite.internal.processors.cache.distributed.dht.preloader.GridDhtPartitionsExchangeFuture
|    674 | init .  in     ''
|   2419 | body0   in org.apache.ignite.internal.processors.cache.GridCachePartitionExchangeManager$ExchangeWorker
|   2299 | body .  in     ''
|    110 | run     in org.apache.ignite.internal.util.worker.GridWorker
^    745 | run . . in java.lang.Thread
```


